### PR TITLE
feat: Initial instagram integration implementation

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -8,7 +8,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install git tini -y
+RUN apt-get install git tini build-essential -y
 
 RUN pip install --upgrade pip
 RUN pip install poetry

--- a/.docker/scraper/Dockerfile
+++ b/.docker/scraper/Dockerfile
@@ -7,7 +7,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 
 WORKDIR /app
 
-RUN apt-get update && apt-get upgrade -y && apt-get install git tini -y
+RUN apt-get update && apt-get upgrade -y && apt-get install git tini build-essential -y
 RUN pip install --upgrade pip
 RUN pip install poetry
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# deprem-yardim-backend
+# Afet Harita Backend
+
+https://afetharita.com için back-end projesi. https://api.afetharita.com adresinden erişilebilir.
+
+Diğer projeler: https://github.com/acikkaynak/deprem-yardim-projesi
+
+## Kullanılan teknolojiler
+
+Python (Django), Postgres (PostgreSQL), Redis, AWS (Elastic Load Balancer, ECS, AWS Fargate), OpenAI (Görsellerin metine çevirilmesi)
+
+# Projeyi çalıştırmak
+
+## Bağımlılıklar:
+
+[Docker](https://www.docker.com) (opsiyonel): Geliştirmek için şart değilse de gereksinimleri yüklemeyi ve geliştirme yapmayı kolaylaştıracaktır. Canlıda proje docker üzerinde AWS ECS'lerde çalışmaktadır.
+
+[PostgreSql](https://www.postgresql.org): Veritabanı olarak kullanılmaktadır. Adresten doğrudan bilgisayarınıza indirebilir ya da [docker imajını](https://hub.docker.com/_/postgres) kullanabilirsiniz.
+
+[Redis](https://redis.io): Asenkron Celery görevleri için kuyruk ve cache olarak kullanılmaktadır. Doğrudan bilgisayarınıza indirebilir (Linux için) ya da [docker imajını](https://hub.docker.com/_/redis) kullanabilirsiniz. Windows'ta son versiyon doğrudan çalışmadığı için WSL ile docker'da çalıştırmak en iyi seçenek.
+
+## Geliştirme ortamının hazırlanması
+
+Docker yükledikten sonra tüm projeyi docker-compose ile çalıştırmak için
+
+```sh
+docker-compose up -d
+```
+
+Geliştirme için sadece postgres ve redisi ayağa kaldırmak için:
+
+```sh
+docker-compose up -d postgres redis
+```
+
+## Python
+
+Python bağımlılık yönetimi poetry ile sağlanmaktadır.
+
+```
+pip install poetry
+poetry install
+```
+
+ile gerekli paketleri yükleyebilirsiniz. Poetry kendi ortamını oluşturup paketleri oraya yükleyecektir.
+
+Daha sonra ortam değişkenlerini ayarlayın. .env.template dosyasını .env adıyla kopyalayıp gerekli ayarları yapın. Compose'dan gelen örnek ayarlarla aşağıdaki gibi olacaktır:
+
+```sh
+DJANGO_SECRET_KEY= # django için secret-key
+POSTGRES_PASSWORD=debug
+POSTGRES_USER=debug
+POSTGRES_DB=debug
+POSTGRES_HOST=trquake-database
+POSTGRES_PORT=5432
+CELERY_BROKER_URL=trquake-redis
+ZEKAI_USERNAME= # zekai.io kullanıcı adı
+ZEKAI_PASSWORD= # zekai.io şifre
+DEFAULT_ADMIN_PASSWORD= # ilk oluşturulan admin kullanıcısı için şifre
+```
+
+Django Secret key oluşturmak için:
+
+```sh
+python
+>>> from django.core.management.utils import get_random_secret_key
+>>> print(get_random_secret_key())
+```
+
+Projeyi development modunda açmak için:
+
+```sh
+django-admin createsuperuser
+django-admin migrate
+django-admin runserver
+```
+
+Celery için geliştirilen taskları çalıştırmak için:
+
+```sh
+celery -A trquake.celery.app worker -B -l DEBUG
+```

--- a/applications/core/pagination.py
+++ b/applications/core/pagination.py
@@ -14,10 +14,10 @@ class LocationPagination(PageNumberPagination):
 
 class AreaPagination(PageNumberPagination):
     """
-    Custom pagination for the Area API.
+    UNUSED for now: Custom pagination for the Area API.
 
-    Max page size is set to 200 and can be changed depending on our choice.
+    Max page size is set to 4000 and can be changed depending on our choice.
     """
     page_size_query_param = "page_size"
-    max_page_size = 200
+    max_page_size = 4000
     page_size = 50

--- a/applications/tweets/serializers.py
+++ b/applications/tweets/serializers.py
@@ -21,3 +21,4 @@ class LocationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = ["id", "formatted_address", "loc", "viewport", "raw", "resolution"]
+

--- a/applications/tweets/urls.py
+++ b/applications/tweets/urls.py
@@ -1,8 +1,9 @@
 from rest_framework.routers import DefaultRouter
-from tweets.views import LocationViewSet, AreaViewSet
+from tweets.views import LocationViewSet, AreaViewSet, CityByCityCountView
+from django.urls import path
 
 router = DefaultRouter(trailing_slash=False)
 router.register("locations", LocationViewSet, basename="list-locations")
 router.register("areas", AreaViewSet, basename="list-area")
 
-urlpatterns = router.urls
+urlpatterns = [path("cities", CityByCityCountView.as_view())] + router.urls

--- a/applications/tweets/urls.py
+++ b/applications/tweets/urls.py
@@ -1,9 +1,10 @@
 from rest_framework.routers import DefaultRouter
-from tweets.views import LocationViewSet, AreaViewSet, CityByCityCountView
+from tweets.views import LocationViewSet, AreaViewSet, AreasCountViewSet, CityByCityCountView
 from django.urls import path
 
 router = DefaultRouter(trailing_slash=False)
 router.register("locations", LocationViewSet, basename="list-locations")
+router.register("areas/count", AreasCountViewSet, basename="count-area")
 router.register("areas", AreaViewSet, basename="list-area")
 
 urlpatterns = [path("cities", CityByCityCountView.as_view())] + router.urls

--- a/applications/tweets/views.py
+++ b/applications/tweets/views.py
@@ -24,25 +24,7 @@ class AreaViewSet(GenericViewSet):
     serializer_class = LocationSerializer
     queryset = Location.objects.select_related("address", "address__tweet").all()
 
-    def list(self, request: Request, *args, **kwargs) -> Response:
-        """
-        list method retrieves a list of objects in the queryset based on the bounds defined by the
-         ne_lat, ne_lng, sw_lat, sw_lng parameters provided in the request query_params.
-
-        The method returns an HTTP 400 BAD REQUEST error if any of the four parameters are not provided in the query.
-        If the parameters are not float values, an HTTP error is returned.
-
-        If the input is valid, the method filters the queryset based on the bounds and returns a serialized list of
-        objects in the queryset in an HTTP 200 OK response.
-
-        Parameters:
-        request (Request): The incoming request object.
-        *args: Additional arguments passed to the method.
-        **kwargs: Additional keyword arguments passed to the method.
-
-        Returns:
-        Response: A serialized list of objects in the queryset within the defined bounds.
-        """
+    def get_queryset(self):
         ne_lat = self.request.query_params.get("ne_lat")
         ne_lng = self.request.query_params.get("ne_lng")
         sw_lat = self.request.query_params.get("sw_lat")
@@ -64,18 +46,43 @@ class AreaViewSet(GenericViewSet):
         except ValueError:
             raise ValidationError("Please provide float value.")
 
-        self.queryset = self.get_queryset().filter(
+        return self.queryset.filter(
             northeast_lat__lte=ne_lat,
             northeast_lng__gte=ne_lng,
             southwest_lat__lte=sw_lat,
             southwest_lng__gte=sw_lng,
         )
 
-        serializer = self.serializer_class(self.queryset, many=True)
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        """
+        list method retrieves a list of objects in the queryset based on the bounds defined by the
+         ne_lat, ne_lng, sw_lat, sw_lng parameters provided in the request query_params.
+
+        The method returns an HTTP 400 BAD REQUEST error if any of the four parameters are not provided in the query.
+        If the parameters are not float values, an HTTP error is returned.
+
+        If the input is valid, the method filters the queryset based on the bounds and returns a serialized list of
+        objects in the queryset in an HTTP 200 OK response.
+
+        Parameters:
+        request (Request): The incoming request object.
+        *args: Additional arguments passed to the method.
+        **kwargs: Additional keyword arguments passed to the method.
+
+        Returns:
+        Response: A serialized list of objects in the queryset within the defined bounds.
+        """
+        queryset = self.get_queryset()
+        serializer = self.serializer_class(queryset, many=True)
         return Response(
-            data={"count": self.queryset.count(), "results": serializer.data},
+            data={"count": queryset.count(), "results": serializer.data},
             status=status.HTTP_200_OK,
         )
+
+
+class AreasCountViewSet(AreaViewSet):
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        return Response({"count": self.get_queryset().count()})
 
 
 class CityByCityCountView(APIView):

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -9,7 +9,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install git -y
+RUN apt-get install git build-essential -y
 
 RUN pip install --upgrade pip
 RUN pip install poetry

--- a/task-definition-scr.json
+++ b/task-definition-scr.json
@@ -57,7 +57,7 @@
     }
   ],
   "placementConstraints": [],
-  "memory": 1024,
+  "memory": "1024",
   "taskRoleArn": "arn:aws:iam::630179636432:role/ecsTaskExecutionRole",
   "compatibilities": [
     "EC2",
@@ -130,7 +130,7 @@
     "operatingSystemFamily": "LINUX",
     "cpuArchitecture": null
   },
-  "cpu": 512,
+  "cpu": "512",
   "revision": 3,
   "status": "ACTIVE",
   "inferenceAccelerators": null,

--- a/task-definition-scr.json
+++ b/task-definition-scr.json
@@ -57,7 +57,7 @@
     }
   ],
   "placementConstraints": [],
-  "memory": "512",
+  "memory": 1024,
   "taskRoleArn": "arn:aws:iam::630179636432:role/ecsTaskExecutionRole",
   "compatibilities": [
     "EC2",
@@ -130,7 +130,7 @@
     "operatingSystemFamily": "LINUX",
     "cpuArchitecture": null
   },
-  "cpu": "256",
+  "cpu": 512,
   "revision": 3,
   "status": "ACTIVE",
   "inferenceAccelerators": null,

--- a/task-definition.json
+++ b/task-definition.json
@@ -143,7 +143,7 @@
     "operatingSystemFamily": "LINUX",
     "cpuArchitecture": "X86_64"
   },
-  "cpu": "512",
+  "cpu": "2048",
   "revision": 5,
   "status": "ACTIVE",
   "inferenceAccelerators": null,

--- a/task-definition.json
+++ b/task-definition.json
@@ -64,7 +64,7 @@
     }
   ],
   "placementConstraints": [],
-  "memory": "1024",
+  "memory": "4096",
   "taskRoleArn": "arn:aws:iam::630179636432:role/ecsTaskExecutionRole",
   "compatibilities": [
     "EC2",


### PR DESCRIPTION
This PR implements an initial implementation of a similar functionality than the existing for Twitter, but for Instagram.


Few notes:

- Hashtags to follow can be defined from the admin interface
- It uses the [instagrapi](https://github.com/adw0rd/instagrapi) library to handle the communication with Instagram 
- It allows to get data without authentication (even though Instagram may block us), authenticate with username and password provided via settings (this might fail in some cases due to Instagram requiring a 2FA>
- How many recent posts should be gathered per each hashtag can be configured via settings 
- It still uses the existing Address/Location models used for Twitter, so we can keep using the same endpoints
- Also uses the `ask_to_zekai` functionality to get the Location/Address, even though from Instagram we can get the address and coordinates from the posts
- The `LocationSerializer` includes a new `instagram_raw` field. It could also be made to just use the `raw` field for both Twitter/Instagram getting the serializer dynamically 
- It might require proper testing